### PR TITLE
FAI-958 AAN DfE SignIn integration with Access Denied Page

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,7 @@ stages:
   variables:
   - group: DevTest Management Resources
   - group: AT DevTest Shared Resources
+  - group: AT das-admin-aan-web 
   jobs:
   - template: pipeline-templates/job/deploy.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,6 +64,7 @@ stages:
   variables:
   - group: DevTest Management Resources
   - group: TEST DevTest Shared Resources
+  - group: TEST das-admin-aan-web 
   jobs:
   - template: pipeline-templates/job/deploy.yml
     parameters:

--- a/azure/template.json
+++ b/azure/template.json
@@ -64,8 +64,11 @@
             "type": "string"
         },
         "utcValue": {
-            "type": "string",
-            "defaultValue": "[utcNow()]"
+          "type": "string",
+          "defaultValue": "[utcNow()]"
+        },
+        "cdnUrl": {
+          "type": "string"
         }
     },
     "variables": {
@@ -193,6 +196,10 @@
                                 {
                                     "name": "LoggingRedisKey",
                                     "value": "[parameters('loggingRedisKey')]"
+                                },
+                                {
+                                    "name": "cdn:url",
+                                    "value": "[parameters('cdnUrl')]"
                                 }
                             ]
                         }

--- a/azure/template.json
+++ b/azure/template.json
@@ -73,7 +73,7 @@
         "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
         "resourceGroupName": "[concat(variables('resourceNamePrefix'), '-rg')]",
         "appServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",
-        "configNames": "SFA.DAS.AdminAan.Web"
+        "configNames": "SFA.DAS.AdminAan.Web,SFA.DAS.Provider.DfeSignIn"
     },
     "resources": [
         {

--- a/azure/template.json
+++ b/azure/template.json
@@ -198,7 +198,7 @@
                                     "value": "[parameters('loggingRedisKey')]"
                                 },
                                 {
-                                    "name": "cdn:url",
+                                    "name": "Cdn:Url",
                                     "value": "[parameters('cdnUrl')]"
                                 }
                             ]

--- a/src/SFA.DAS.Admin.Aan.Web.UnitTests/Controllers/AccountControllerTest.cs
+++ b/src/SFA.DAS.Admin.Aan.Web.UnitTests/Controllers/AccountControllerTest.cs
@@ -1,0 +1,59 @@
+﻿using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using SFA.DAS.Admin.Aan.Web.Configuration;
+using SFA.DAS.Admin.Aan.Web.Controllers;
+using SFA.DAS.Admin.Aan.Web.Models.Account;
+
+namespace SFA.DAS.Admin.Aan.Web.UnitTests.Controllers
+{
+    [TestFixture]
+    public class AccountControllerTest
+    {
+        private AccountController _controller = null!;
+        private Mock<ILogger<AccountController>> _mockLogger = null!;
+        private Mock<IConfiguration> _mockConfiguration = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockConfiguration = new Mock<IConfiguration>();
+            _mockLogger = new Mock<ILogger<AccountController>>();
+        }
+
+
+        [TestCase("test", "https://test-services.signin.education.gov.uk/approvals/select-organisation?action=request-service", true)]
+        [TestCase("pp", "https://test-services.signin.education.gov.uk/approvals/select-organisation?action=request-service", true)]
+        [TestCase("local", "https://test-services.signin.education.gov.uk/approvals/select-organisation?action=request-service", false)]
+        [TestCase("prd", "https://services.signin.education.gov.uk/approvals/select-organisation?action=request-service", false)]
+        public void When_AccessDenied_Then_ViewIsReturned(string env, string helpLink, bool useDfESignIn)
+        {
+            //arrange
+            var appConfig = new ApplicationConfiguration { UseDfESignIn = useDfESignIn };
+            var mockIOptions = new Mock<IOptions<ApplicationConfiguration>>();
+            mockIOptions.Setup(ap => ap.Value).Returns(appConfig);
+            _mockConfiguration.Setup(x => x["ResourceEnvironmentName"]).Returns(env);
+            _controller = new AccountController(_mockLogger.Object, mockIOptions.Object, _mockConfiguration.Object)
+            {
+                ControllerContext = new ControllerContext()
+            };
+            _controller.ControllerContext.HttpContext = new DefaultHttpContext();
+
+            //sut
+            var result = (ViewResult)_controller.AccessDenied();
+
+            //assert
+            result.Should().NotBeNull();
+            result.ViewName.Should().Be(nameof(AccountController.AccessDenied));
+
+            var actualModel = result.Model as Error403ViewModel;
+            actualModel.Should().NotBeNull();
+            actualModel?.HelpPageLink.Should().Be(helpLink);
+            actualModel?.UseDfESignIn.Should().Be(useDfESignIn);
+        }
+    }
+}

--- a/src/SFA.DAS.Admin.Aan.Web.UnitTests/Extensions/UserExtensionsTest.cs
+++ b/src/SFA.DAS.Admin.Aan.Web.UnitTests/Extensions/UserExtensionsTest.cs
@@ -1,0 +1,76 @@
+﻿using FluentAssertions;
+using SFA.DAS.Admin.Aan.Web.Extensions;
+using SFA.DAS.DfESignIn.Auth.Constants;
+using SFA.DAS.Testing.AutoFixture;
+using System.Security.Claims;
+
+namespace SFA.DAS.Admin.Aan.Web.UnitTests.Extensions
+{
+    public class UserExtensionsTest
+    {
+        [Test, MoqAutoData]
+        public void GetFirstName_Returns_ExpectedResults(string firstName)
+        {
+            // arrange
+            ClaimsIdentity identity = new();
+            identity.AddClaim(new Claim(ClaimName.GivenName, firstName));
+            var principal = new ClaimsPrincipal(identity);
+
+            //sut
+            var actual = principal.GetFirstName();
+
+            //assert
+            actual.Should().NotBeNullOrEmpty();
+            actual.Should().Be(firstName);
+        }
+
+        [Test, MoqAutoData]
+        public void GetLastName_Returns_ExpectedResults(string lastName)
+        {
+            // arrange
+            ClaimsIdentity identity = new();
+            identity.AddClaim(new Claim(ClaimName.FamilyName, lastName));
+            var principal = new ClaimsPrincipal(identity);
+
+            //sut
+            var actual = principal.GetLastName();
+
+            //assert
+            actual.Should().NotBeNullOrEmpty();
+            actual.Should().Be(lastName);
+        }
+
+        [Test, MoqAutoData]
+        public void GetEmail_Returns_ExpectedResults(string email)
+        {
+            // arrange
+            ClaimsIdentity identity = new();
+            identity.AddClaim(new Claim(ClaimName.Email, email));
+            var principal = new ClaimsPrincipal(identity);
+
+            //sut
+            var actual = principal.GetEmail();
+
+            //assert
+            actual.Should().NotBeNullOrEmpty();
+            actual.Should().Be(email);
+        }
+
+        [Test, MoqAutoData]
+        public void GetDisplay_Returns_ExpectedResults(string firstName, string lastName)
+        {
+            // arrange
+            ClaimsIdentity identity = new();
+            identity.AddClaim(new Claim(ClaimName.GivenName, firstName));
+            identity.AddClaim(new Claim(ClaimName.FamilyName, lastName));
+            var principal = new ClaimsPrincipal(identity);
+
+            //sut
+            var actual = principal.GetDisplayName();
+
+            //assert
+            actual.Should().NotBeNullOrEmpty();
+            actual.Should().Be($"{firstName} {lastName}");
+        }
+    }
+}

--- a/src/SFA.DAS.Admin.Aan.Web.UnitTests/Models/Account/WhenBuildingError403ViewModel.cs
+++ b/src/SFA.DAS.Admin.Aan.Web.UnitTests/Models/Account/WhenBuildingError403ViewModel.cs
@@ -1,0 +1,35 @@
+﻿using SFA.DAS.Admin.Aan.Web.Models.Account;
+
+namespace SFA.DAS.Admin.Aan.Web.UnitTests.Models.Account
+{
+    public class WhenBuildingError403ViewModel
+    {
+        [Test]
+        public void Then_The_HelpPage_Link_Is_Correct_For_Production_Environment()
+        {
+            var actual = new Error403ViewModel("prd");
+
+            Assert.That(actual.HelpPageLink, Is.Not.Null);
+            Assert.That(actual.HelpPageLink, Is.EqualTo("https://services.signin.education.gov.uk/approvals/select-organisation?action=request-service"));
+        }
+
+        [Test]
+        public void Then_The_HelpPage_Link_Is_Correct_For_Non_Production_Environment()
+        {
+            var actual = new Error403ViewModel("test");
+
+            Assert.That(actual.HelpPageLink, Is.Not.Null);
+            Assert.That(actual.HelpPageLink, Is.EqualTo("https://test-services.signin.education.gov.uk/approvals/select-organisation?action=request-service"));
+        }
+
+        [TestCase("")]
+        [TestCase(null)]
+        public void Then_The_HelpPage_Link_Is_Correct_When_Environment_Is_Null(string env)
+        {
+            var actual = new Error403ViewModel(env);
+
+            Assert.That(actual.HelpPageLink, Is.Not.Null);
+            Assert.That(actual.HelpPageLink, Is.EqualTo("https://services.signin.education.gov.uk/approvals/select-organisation?action=request-service"));
+        }
+    }
+}

--- a/src/SFA.DAS.Admin.Aan.Web/Authentication/AddAuthenticationServicesExtension.cs
+++ b/src/SFA.DAS.Admin.Aan.Web/Authentication/AddAuthenticationServicesExtension.cs
@@ -44,8 +44,8 @@ public static class AddAuthenticationServicesExtension
                 })
                 .AddWsFederation(options =>
                 {
-                    options.Wtrealm = authConfig.WtRealm;
-                    options.MetadataAddress = authConfig.MetadataAddress;
+                    options.Wtrealm = authConfig?.WtRealm;
+                    options.MetadataAddress = authConfig?.MetadataAddress;
                     options.TokenValidationParameters.RoleClaimType = Roles.RoleClaimType;
                     options.Events.OnSecurityTokenValidated = async (ctx) =>
                     {

--- a/src/SFA.DAS.Admin.Aan.Web/Authentication/AddAuthenticationServicesExtension.cs
+++ b/src/SFA.DAS.Admin.Aan.Web/Authentication/AddAuthenticationServicesExtension.cs
@@ -10,6 +10,8 @@ namespace SFA.DAS.Admin.Aan.Web.Authentication;
 [ExcludeFromCodeCoverage]
 public static class AddAuthenticationServicesExtension
 {
+    private const string CookieAuthName = "SFA.DAS.AdminService.Web.Auth";
+
     public static IServiceCollection AddAuthenticationServices(this IServiceCollection services, IConfiguration configuration)
     {
         var applicationConfiguration = configuration.GetSection(nameof(ApplicationConfiguration)).Get<ApplicationConfiguration>();
@@ -18,7 +20,7 @@ public static class AddAuthenticationServicesExtension
         {
             services.AddAndConfigureDfESignInAuthentication(
                 configuration,
-                $"{typeof(AddAuthenticationServicesExtension).Assembly.GetName().Name}.Auth",
+                CookieAuthName,
                 typeof(CustomServiceRole),
                 DfESignIn.Auth.Enums.ClientName.ServiceAdmin,
                 "/SignOut",

--- a/src/SFA.DAS.Admin.Aan.Web/Authentication/CustomServiceRole.cs
+++ b/src/SFA.DAS.Admin.Aan.Web/Authentication/CustomServiceRole.cs
@@ -1,0 +1,12 @@
+﻿using SFA.DAS.DfESignIn.Auth.Enums;
+using SFA.DAS.DfESignIn.Auth.Interfaces;
+using System.Security.Claims;
+
+namespace SFA.DAS.Admin.Aan.Web.Authentication
+{
+    public class CustomServiceRole : ICustomServiceRole
+    {
+        public string RoleClaimType => ClaimTypes.Role;
+        public CustomServiceRoleValueType RoleValueType => CustomServiceRoleValueType.Code;
+    }
+}

--- a/src/SFA.DAS.Admin.Aan.Web/Configuration/ApplicationConfiguration.cs
+++ b/src/SFA.DAS.Admin.Aan.Web/Configuration/ApplicationConfiguration.cs
@@ -8,4 +8,8 @@ public class ApplicationConfiguration
     public string RedisConnectionString { get; set; } = null!;
     public string EmployerAanUrl { get; set; } = null!;
     public string ApprenticeAanUrl { get; set; } = null!;
+    /// <summary>
+    /// Gets or Sets UseDfESignIn Config Value.
+    /// </summary>
+    public bool UseDfESignIn { get; set; }
 }

--- a/src/SFA.DAS.Admin.Aan.Web/Controllers/AccountController.cs
+++ b/src/SFA.DAS.Admin.Aan.Web/Controllers/AccountController.cs
@@ -8,6 +8,7 @@ using System.Security.Claims;
 using Microsoft.Extensions.Options;
 using SFA.DAS.Admin.Aan.Web.Configuration;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using SFA.DAS.Admin.Aan.Web.Models.Account;
 
 namespace SFA.DAS.Admin.Aan.Web.Controllers;
 
@@ -15,10 +16,15 @@ public class AccountController : Controller
 {
     private readonly ILogger<AccountController> _logger;
     private readonly ApplicationConfiguration _applicationConfiguration;
+    private readonly IConfiguration _configuration;
 
-    public AccountController(ILogger<AccountController> logger, IOptions<ApplicationConfiguration> applicationConfiguration)
+    public AccountController(
+        ILogger<AccountController> logger,
+        IOptions<ApplicationConfiguration> applicationConfiguration,
+        IConfiguration configuration)
     {
         _logger = logger;
+        _configuration = configuration;
         _applicationConfiguration = applicationConfiguration.Value;
     }
 
@@ -76,6 +82,7 @@ public class AccountController : Controller
     }
 
     [HttpGet]
+    [Route("~/error/403")]
     public IActionResult AccessDenied()
     {
         if (HttpContext.User != null)
@@ -86,6 +93,6 @@ public class AccountController : Controller
             _logger.LogError("AccessDenied - User '{userName}' does not have a valid role. They have the following roles: {roles}", userName, string.Join(",", roles));
         }
 
-        return View("AccessDenied");
+        return View("AccessDenied", new Error403ViewModel(_configuration["ResourceEnvironmentName"]) { UseDfESignIn = _applicationConfiguration.UseDfESignIn });
     }
 }

--- a/src/SFA.DAS.Admin.Aan.Web/Controllers/AccountController.cs
+++ b/src/SFA.DAS.Admin.Aan.Web/Controllers/AccountController.cs
@@ -93,6 +93,6 @@ public class AccountController : Controller
             _logger.LogError("AccessDenied - User '{userName}' does not have a valid role. They have the following roles: {roles}", userName, string.Join(",", roles));
         }
 
-        return View("AccessDenied", new Error403ViewModel(_configuration["ResourceEnvironmentName"]) { UseDfESignIn = _applicationConfiguration.UseDfESignIn });
+        return View("AccessDenied", new Error403ViewModel(_configuration["ResourceEnvironmentName"] ?? string.Empty) { UseDfESignIn = _applicationConfiguration.UseDfESignIn });
     }
 }

--- a/src/SFA.DAS.Admin.Aan.Web/Controllers/AccountController.cs
+++ b/src/SFA.DAS.Admin.Aan.Web/Controllers/AccountController.cs
@@ -83,6 +83,7 @@ public class AccountController : Controller
 
     [HttpGet]
     [Route("~/error/403")]
+    [Route("~/Account/AccessDenied")]
     public IActionResult AccessDenied()
     {
         if (HttpContext.User != null)

--- a/src/SFA.DAS.Admin.Aan.Web/Extensions/UserExtensions.cs
+++ b/src/SFA.DAS.Admin.Aan.Web/Extensions/UserExtensions.cs
@@ -1,17 +1,21 @@
 ﻿using SFA.DAS.Admin.Aan.Web.Authentication;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
+using SFA.DAS.DfESignIn.Auth.Constants;
+using SFA.DAS.DfESignIn.Auth.Extensions;
 
 namespace SFA.DAS.Admin.Aan.Web.Extensions;
 
 [ExcludeFromCodeCoverage]
 public static class UserExtensions
 {
-    public static string GetFirstName(this ClaimsPrincipal principal) => principal.FindFirst(StaffClaims.GivenName)!.Value;
+    public static string GetFirstName(this ClaimsPrincipal principal) => principal.FindFirst(StaffClaims.GivenName)?.Value is null ? principal.GetClaimValue(ClaimName.GivenName) : principal.FindFirst(StaffClaims.GivenName)!.Value;
 
-    public static string GetLastName(this ClaimsPrincipal principal) => principal.FindFirst(StaffClaims.Surname)!.Value;
+    public static string GetLastName(this ClaimsPrincipal principal) => principal.FindFirst(StaffClaims.Surname)?.Value is null ? principal.GetClaimValue(ClaimName.FamilyName) : principal.FindFirst(StaffClaims.Surname)!.Value;
 
-    public static string GetEmail(this ClaimsPrincipal principal) => principal.FindFirst(StaffClaims.UserId)!.Value;
+    public static string GetEmail(this ClaimsPrincipal principal) => principal.FindFirst(StaffClaims.UserId)?.Value is null ? principal.GetClaimValue(ClaimName.Email) : principal.FindFirst(StaffClaims.UserId)!.Value;
 
     public static bool HasValidRole(this ClaimsPrincipal user) => user.IsInRole(Roles.ManageEventsRole) || user.IsInRole(Roles.ManageMembersRole);
+
+    public static string GetDisplayName(this ClaimsPrincipal user) => $"{GetFirstName(user)} {GetLastName(user)}";
 }

--- a/src/SFA.DAS.Admin.Aan.Web/Models/Account/Error403ViewModel.cs
+++ b/src/SFA.DAS.Admin.Aan.Web/Models/Account/Error403ViewModel.cs
@@ -1,0 +1,25 @@
+﻿namespace SFA.DAS.Admin.Aan.Web.Models.Account
+{
+    public class Error403ViewModel
+    {
+        private readonly string _integrationUrlPart = string.Empty;
+
+        public Error403ViewModel(string environment)
+        {
+            if (!string.IsNullOrEmpty(environment) && !environment.Equals("prd", StringComparison.CurrentCultureIgnoreCase))
+            {
+                _integrationUrlPart = "test-";
+            }
+        }
+
+        /// <summary>
+        /// Gets DfESignIn Select service link.
+        /// </summary>
+        public string HelpPageLink => $"https://{_integrationUrlPart}services.signin.education.gov.uk/approvals/select-organisation?action=request-service";
+
+        /// <summary>
+        /// Gets or Sets UseDfESignIn config property.
+        /// </summary>
+        public bool UseDfESignIn { get; set; }
+    }
+}

--- a/src/SFA.DAS.Admin.Aan.Web/Program.cs
+++ b/src/SFA.DAS.Admin.Aan.Web/Program.cs
@@ -11,7 +11,6 @@ using SFA.DAS.Admin.Aan.Web.HealthCheck;
 var builder = WebApplication.CreateBuilder(args);
 
 var rootConfiguration = builder.Configuration.LoadConfiguration();
-
 var applicationConfiguration = rootConfiguration.Get<ApplicationConfiguration>();
 builder.Services.AddSingleton(applicationConfiguration);
 
@@ -32,7 +31,7 @@ builder.Services
         options.Filters.Add<RequiresMemberActionAttribute>();
     })
     .AddSessionStateTempDataProvider();
-
+builder.Services.Configure<ApplicationConfiguration>(rootConfiguration.GetSection(nameof(applicationConfiguration)));
 builder.Services.AddHealthChecks()
     .AddCheck<AdminAanOuterApiHealthCheck>(AdminAanOuterApiHealthCheck.HealthCheckResultDescription,
         failureStatus: HealthStatus.Unhealthy,

--- a/src/SFA.DAS.Admin.Aan.Web/Program.cs
+++ b/src/SFA.DAS.Admin.Aan.Web/Program.cs
@@ -11,6 +11,7 @@ using SFA.DAS.Admin.Aan.Web.HealthCheck;
 var builder = WebApplication.CreateBuilder(args);
 
 var rootConfiguration = builder.Configuration.LoadConfiguration();
+
 var applicationConfiguration = rootConfiguration.Get<ApplicationConfiguration>();
 builder.Services.AddSingleton(applicationConfiguration);
 

--- a/src/SFA.DAS.Admin.Aan.Web/SFA.DAS.Admin.Aan.Web.csproj
+++ b/src/SFA.DAS.Admin.Aan.Web/SFA.DAS.Admin.Aan.Web.csproj
@@ -1,35 +1,43 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="CommonMark.NET" Version="0.15.1" />
-    <PackageReference Include="FluentValidation" Version="11.6.0" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.6.0" />
-    <PackageReference Include="MediatR" Version="12.1.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="SFA.DAS.AdminService.Common" Version="0.1.75" />
-    <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />
-    <PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.65" />
-    <PackageReference Include="SFA.DAS.Http" Version="3.2.69" />
-    <PackageReference Include="RestEase" Version="1.6.4" />
-    <PackageReference Include="RestEase.HttpClientFactory" Version="1.6.4" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.22.0" />
-    <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.21" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="6.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.20" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="CommonMark.NET" Version="0.15.1" />
+		<PackageReference Include="FluentValidation" Version="11.6.0" />
+		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.6.0" />
+		<PackageReference Include="MediatR" Version="12.1.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+		<PackageReference Include="SFA.DAS.AdminService.Common" Version="0.1.75" />
+		<PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />
+		<PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.65" />
+		<PackageReference Include="SFA.DAS.Http" Version="3.2.69" />
+		<PackageReference Include="RestEase" Version="1.6.4" />
+		<PackageReference Include="RestEase.HttpClientFactory" Version="1.6.4" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.22.0" />
+		<PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.21" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="6.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.20" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\SFA.DAS.Admin.Aan.Application\SFA.DAS.Admin.Aan.Application.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\SFA.DAS.Admin.Aan.Application\SFA.DAS.Admin.Aan.Application.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<Content Update="appsettings.json">
+			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+		</Content>
+		<Content Update="appsettings.Development.json">
+			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+		</Content>
+	</ItemGroup>
 
 </Project>

--- a/src/SFA.DAS.Admin.Aan.Web/SFA.DAS.Admin.Aan.Web.csproj
+++ b/src/SFA.DAS.Admin.Aan.Web/SFA.DAS.Admin.Aan.Web.csproj
@@ -13,11 +13,15 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.6.0" />
     <PackageReference Include="MediatR" Version="12.1.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
     <PackageReference Include="SFA.DAS.AdminService.Common" Version="0.1.75" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />
+    <PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.65" />
     <PackageReference Include="SFA.DAS.Http" Version="3.2.69" />
     <PackageReference Include="RestEase" Version="1.6.4" />
     <PackageReference Include="RestEase.HttpClientFactory" Version="1.6.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.22.0" />
     <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.21" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="6.0.11" />

--- a/src/SFA.DAS.Admin.Aan.Web/SFA.DAS.Admin.Aan.Web.csproj
+++ b/src/SFA.DAS.Admin.Aan.Web/SFA.DAS.Admin.Aan.Web.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
 		<PackageReference Include="SFA.DAS.AdminService.Common" Version="0.1.75" />
 		<PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />
-		<PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.65" />
+		<PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.67" />
 		<PackageReference Include="SFA.DAS.Http" Version="3.2.69" />
 		<PackageReference Include="RestEase" Version="1.6.4" />
 		<PackageReference Include="RestEase.HttpClientFactory" Version="1.6.4" />

--- a/src/SFA.DAS.Admin.Aan.Web/Views/Account/AccessDenied.cshtml
+++ b/src/SFA.DAS.Admin.Aan.Web/Views/Account/AccessDenied.cshtml
@@ -1,13 +1,37 @@
-﻿@model AdminHubViewModel
+﻿@model SFA.DAS.Admin.Aan.Web.Models.Account.Error403ViewModel
 @{
-    ViewData["Title"] = "Access denied";
+    ViewBag.Title = "You aren't approved – Apprenticeship Ambassadors Network";
 }
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">Access denied</h1>
-        <p class="govuk-body-l">Your account does not have sufficient privileges.</p>
+    @if (Model.UseDfESignIn)
+    {
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">
+                You aren't approved to view this page
+            </h1>
+            <p class="govuk-body">
+                To view this page, you need:
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>approval to use this service</li>
+                <li>the correct service role to access this page</li>
+            </ul>
+            <p class="govuk-body">
+                You can <a href="@Model.HelpPageLink" target="_blank" rel="noopener noreferrer">request access to this service in your DfE Sign-in.</a> You can also use this link to request a higher service role.
+            </p>
+            <p class="govuk-body">
+                The DfE Sign-in approver inside your organisation will need to approve your request.
+            </p>
+        </div>
+    }
+    else
+    {
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Access denied</h1>
+            <p class="govuk-body-l">Your account does not have sufficient privileges.</p>
 
-        <p class="govuk-body">If you are experiencing difficulty accessing the area of the site you need, first contact an/the account owner to ensure you have the correct role assigned to your account.</p>
-    </div>
+            <p class="govuk-body">If you are experiencing difficulty accessing the area of the site you need, first contact an/the account owner to ensure you have the correct role assigned to your account.</p>
+        </div>
+    }
 </div>

--- a/src/SFA.DAS.Admin.Aan.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.Admin.Aan.Web/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿@using SFA.DAS.AdminService.Common.Extensions;
+﻿@using SFA.DAS.Admin.Aan.Web.Extensions;
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
 
@@ -73,7 +73,7 @@
                     <div class="govuk-grid-column-one-half">
                         <p class="govuk-body-l app-user-header__name">
                             <span class="govuk-visually-hidden">Signed in as </span>
-                            <span>@User.UserDisplayName()</span>&nbsp;
+                            <span>@User.GetDisplayName()</span>&nbsp;
                         </p>
                     </div>
                     <div class="govuk-grid-column-one-half">

--- a/src/SFA.DAS.Admin.Aan.Web/appsettings.json
+++ b/src/SFA.DAS.Admin.Aan.Web/appsettings.json
@@ -7,8 +7,9 @@
   },
   "AllowedHosts": "*",
   "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;",
-  "ConfigNames": "SFA.DAS.AdminAan.Web",
+  "ConfigNames": "SFA.DAS.AdminAan.Web,SFA.DAS.Provider.DfeSignIn",
   "EnvironmentName": "LOCAL",
+  "ResourceEnvironmentName": "LOCAL",
   "cdn": {
     "url": "https://das-prd-frnt-end.azureedge.net"
   }

--- a/src/SFA.DAS.Admin.Aan.Web/appsettings.json
+++ b/src/SFA.DAS.Admin.Aan.Web/appsettings.json
@@ -11,6 +11,6 @@
   "EnvironmentName": "LOCAL",
   "ResourceEnvironmentName": "LOCAL",
   "cdn": {
-    "url": "https://das-prd-frnt-end.azureedge.net"
+    "url": "https://das-test-frnt-end.azureedge.net"
   }
 }


### PR DESCRIPTION
Commit Details:

1. Amended Access Denied Page for DfESignIn Users.
2. Integrate DfESignIn OpenIdConnect as login Auth scheme for Apprenticeship Ambassadors Network
3. Unit Testing included with the test coverage for newly added code.


Story: https://skillsfundingagency.atlassian.net/browse/FAI-958